### PR TITLE
chore: v2.1.1 residuals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Verify build script version plan
         run: bash scripts/build_test.sh
 
+      # `go vet` (the per-module lint task) ignores formatting; this is the
+      # gate for it. Sub-second over the whole tree.
+      - name: Verify Go formatting
+        run: ./scripts/gofmt-check.sh
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Verify Go toolchain pins
         run: ./scripts/go-toolchain.sh
 
+      # Seconds, no build: only build.sh's version-stamp plan (which version a
+      # build stamps, and whether it rebuilds the frontend).
+      - name: Verify build script version plan
+        run: bash scripts/build_test.sh
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22"

--- a/apps/gmux-web/src/day-boundary.test.ts
+++ b/apps/gmux-web/src/day-boundary.test.ts
@@ -94,7 +94,13 @@ describe('watchDayBoundary across a DST transition', () => {
   const savedTZ = process.env.TZ
 
   beforeEach(() => { process.env.TZ = 'America/New_York' })
-  afterEach(() => { process.env.TZ = savedTZ })
+  // Assigning an undefined savedTZ back would store the *string* "undefined",
+  // which Node resolves to UTC — and vitest reuses worker processes across
+  // files, so that would silently move any later TZ-sensitive test to UTC.
+  afterEach(() => {
+    if (savedTZ === undefined) delete process.env.TZ
+    else process.env.TZ = savedTZ
+  })
 
   it('arms 23 hours for the short day, not 24', () => {
     // Sat 2026-03-07 22:00 EST. If the process did not pick the zone up, this

--- a/apps/gmux-web/src/session-actions.test.ts
+++ b/apps/gmux-web/src/session-actions.test.ts
@@ -89,6 +89,10 @@ describe('relaunchDirectoryNotice', () => {
     })).toBe('Rerunning in /home/user instead (/gone/project no longer exists)')
     expect(relaunchDirectoryNotice('resume', { fallback_cwd: '/home/user' }))
       .toBe('Resumed in /home/user instead')
+    // /restart carries the same payload and also reruns a recorded command.
+    expect(relaunchDirectoryNotice('restart', {
+      original_cwd: '/gone/project', fallback_cwd: '/home/user',
+    })).toBe('Restarting in /home/user instead (/gone/project no longer exists)')
   })
 })
 

--- a/apps/gmux-web/src/session-actions.ts
+++ b/apps/gmux-web/src/session-actions.ts
@@ -59,16 +59,19 @@ export function relaunchVerb(
  * runs an arbitrary recorded command, so running it somewhere else is a fact
  * the user has to be told rather than a detail to drop.
  *
+ * `restart` is the same payload from /restart (stop+spawn of a live session),
+ * which substitutes directories by the same rule.
+ *
  * Returns null when nothing was substituted.
  */
 export function relaunchDirectoryNotice(
-  verb: RelaunchVerb,
+  verb: RelaunchVerb | 'restart',
   data: Record<string, unknown> | null | undefined,
 ): string | null {
   const fallback = data?.fallback_cwd
   const original = data?.original_cwd
   if (typeof fallback !== 'string' || !fallback) return null
-  const word = verb === 'resume' ? 'Resumed' : 'Rerunning'
+  const word = verb === 'resume' ? 'Resumed' : verb === 'restart' ? 'Restarting' : 'Rerunning'
   const from = typeof original === 'string' && original ? ` (${original} no longer exists)` : ''
   return `${word} in ${fallback} instead${from}`
 }

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -11,7 +11,7 @@ import {
   navigateToSession, ownDotState, parseConnectURL, peerAppearance, peerOmittedTotal, peerStatusByName, peerStreamOmissions, peers,
   projects, promoteSession, promotionAnnouncements, promotionPending,
   PROMOTION_PENDING_TTL_MS, reconcilePromotionPending, removeSession, reorderSessions,
-  reparentSession, resumeSession, selectedFamilyChild, selectedId, sessions, sessionsLoaded,
+  reparentSession, restartSession, resumeSession, selectedFamilyChild, selectedId, sessions, sessionsLoaded,
   sessionStaleness, setAliveOnly, setFilterSelectors, setHostFilter, setNavigate,
   setSidebarMode, settlePromotion, sidebarActivity, sidebarMode, sidebarSessions, tabHref,
   toUISession, unreadCount, upsertSession, urlHash, urlPath, urlSearch, view, worldLoaded,
@@ -110,6 +110,35 @@ describe('postAction surfaces backend failures as error toasts', () => {
       kind: 'info',
       message: 'Rerunning in /home/user instead (/gone no longer exists)',
     })
+  })
+
+  it('tells the user when a restart was relocated to the fallback directory', async () => {
+    // /restart returns the same substitution payload as /resume, and a restart
+    // reruns the recorded command: the relocation is as user-visible here as
+    // it is for a rerun, so it cannot be dropped just because the button says
+    // "Restart".
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: () => Promise.resolve({
+        ok: true,
+        data: { pid: 9, session_id: 's1', original_cwd: '/gone', fallback_cwd: '/home/user' },
+      }),
+    }))
+    await restartSession('s1')
+    expect(toasts.value).toHaveLength(1)
+    expect(toasts.value[0]).toMatchObject({
+      kind: 'info',
+      message: 'Restarting in /home/user instead (/gone no longer exists)',
+    })
+  })
+
+  it('stays quiet when a restart happened where the session lived', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: () => Promise.resolve({ ok: true, data: { pid: 9, session_id: 's1' } }),
+    }))
+    await restartSession('s1')
+    expect(toasts.value).toHaveLength(0)
   })
 
   it('stays quiet when the relaunch happened where the session lived', async () => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -2125,8 +2125,20 @@ export function resumeSession(sessionId: string, verb: 'resume' | 'rerun' = 'res
   })
 }
 
+/** Restart a live session: stop it and relaunch it in place.
+ *
+ * Reports a substituted directory for the same reason resumeSession does —
+ * /restart returns the same `original_cwd`/`fallback_cwd` payload, and a
+ * restart whose recorded directory is gone reruns the recorded command
+ * somewhere else. Silence there would be a restart that quietly changed where
+ * the session lives. */
 export function restartSession(sessionId: string): Promise<boolean> {
-  return postAction(`/v1/sessions/${sessionId}/restart`, 'Restart')
+  return postAction(`/v1/sessions/${sessionId}/restart`, 'Restart', {
+    onData: data => {
+      const notice = relaunchDirectoryNotice('restart', data)
+      if (notice) pushToast('info', notice)
+    },
+  })
 }
 
 // Family mutations change the single parent edge. Deliberately no optimistic

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -328,7 +328,7 @@ func TestHelpAliases(t *testing.T) {
 		{[]string{"attach", "--help"}, "attach"},
 		{[]string{"kill", "?"}, "kill"},
 		{[]string{"promote", "--help"}, "promote"},
-		{[]string{"promote", "abc", "--help"}, "promote"},       // flagless verbs answer here too
+		{[]string{"promote", "abc", "--help"}, "promote"}, // flagless verbs answer here too
 		{[]string{"reparent", "abc", "def", "--help"}, "reparent"},
 		{[]string{"help", "reparent"}, "reparent"},
 		{[]string{"edit", "--help"}, "edit"},

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -16,8 +16,6 @@ import (
 // Falls back to "dev" for local builds.
 var version = "dev"
 
-
-
 func main() {
 	if len(os.Args) > 2 && os.Args[1] == "__detached-target" {
 		os.Exit(runDetachedTarget(os.Args[2:]))

--- a/cli/gmux/cmd/gmux/main_test.go
+++ b/cli/gmux/cmd/gmux/main_test.go
@@ -303,4 +303,3 @@ func TestGmuxdNeedsStart_StampedDevNeverReplaces(t *testing.T) {
 		t.Error("a stamped dev build must not replace a healthy daemon")
 	}
 }
-

--- a/e2e/tests/terminal-resize.spec.ts
+++ b/e2e/tests/terminal-resize.spec.ts
@@ -78,6 +78,77 @@ test.describe('terminal resize', () => {
     expect(await isPillVisible(page)).toBe(false)
   })
 
+  // The pill's tap handler (fitAndResize) has the same never-commit-a-refusal
+  // rule as the resize path, and it is the rule that keeps the pill itself on
+  // screen: the pill is gated on a non-null viewport, so committing a refused
+  // measurement would make the tap delete the only affordance that recovers
+  // the terminal.
+  test('a pill tap while the shell is collapsed is refused without losing the pill', async ({ page }) => {
+    const before = await getTermState(page)
+    expect(before.termRows!).toBeGreaterThan(4)
+
+    // Another client sizes the PTY away from this viewport, which is the only
+    // thing that raises the pill (the pill is derived purely from
+    // viewport-vs-PTY mismatch).
+    const sessionId = process.env.GMUX_TEST_SESSION_ID!
+    await page.evaluate(async (id) => {
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const ws = new WebSocket(`${proto}//${location.host}/ws/${id}?client=browser`)
+      ;(window as any).__secondClient = ws
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve()
+        ws.onerror = () => reject(new Error('second client failed to connect'))
+      })
+      ws.send(JSON.stringify({ type: 'resize', cols: 40, rows: 10 }))
+    }, sessionId)
+    try {
+      await pollUntil(async () => (await ptySize()).rows === 10 || null,
+        { timeoutMs: 5_000, description: 'the second client resized the PTY to 40x10' })
+      await pollUntil(async () => (await isPillVisible(page)) || null,
+        { timeoutMs: 5_000, description: 'pill appears once the PTY is sized elsewhere' })
+
+      // Collapse below one cell: every measurement is now a refusal.
+      await page.evaluate(() => {
+        (document.querySelector('.terminal-shell') as HTMLElement).style.flex = '0 0 8px'
+      })
+      await page.waitForTimeout(600)
+      expect(await isPillVisible(page), 'the collapse itself must not drop the pill').toBe(true)
+
+      // Tap the pill. A collapsed overlay is not actionable for
+      // locator.click() (zero height), but a real 0-height overlay still
+      // receives a dispatched click — which is exactly the tap a user lands
+      // mid-relayout on a phone.
+      const tapped = await page.evaluate(() => {
+        const el = document.querySelector('.terminal-resize-overlay') as HTMLElement | null
+        if (!el) return false
+        el.click()
+        return true
+      })
+      expect(tapped, 'pill element must exist to be tapped').toBe(true)
+      await page.waitForTimeout(600)
+
+      // The refusal must not have been committed: the pill is still there to
+      // be tapped again, and the PTY was not resized to a non-viable size.
+      expect(await isPillVisible(page), 'a refused tap must leave the pill tappable').toBe(true)
+      expect((await ptySize()).rows, 'a refused tap must not reach the PTY').toBe(10)
+
+      // And the affordance still works once layout recovers.
+      await page.evaluate(() => {
+        (document.querySelector('.terminal-shell') as HTMLElement).style.flex = '0 0 300px'
+      })
+      await page.waitForTimeout(600)
+      await page.evaluate(() => {
+        (document.querySelector('.terminal-resize-overlay') as HTMLElement | null)?.click()
+      })
+      await pollUntil(async () => (await isPillVisible(page)) ? null : true,
+        { timeoutMs: 5_000, description: 'a tap after recovery clears the pill' })
+      await pollUntil(async () => (await ptySize()).rows !== 10 || null,
+        { timeoutMs: 5_000, description: 'the recovered tap resized the PTY' })
+    } finally {
+      await page.evaluate(() => (window as any).__secondClient?.close())
+    }
+  })
+
   test('fresh connection claims at current viewport, ignoring server\'s prior PTY size', async ({ page }) => {
     // Shrink the viewport. Since this page is driving, the server's PTY
     // size follows us down to ~800x500.

--- a/packages/buildversion/buildversion_test.go
+++ b/packages/buildversion/buildversion_test.go
@@ -28,11 +28,11 @@ func TestSameBuildClass(t *testing.T) {
 		want bool
 	}{
 		{"dev", "dev", true},
-		{"dev+aaaaaaaaaaaa", "dev+bbbbbbbbbbbb", true},   // rebuild, same class
-		{"dev", "dev+aaaaaaaaaaaa-dirty", true},          // stamped vs unstamped
+		{"dev+aaaaaaaaaaaa", "dev+bbbbbbbbbbbb", true}, // rebuild, same class
+		{"dev", "dev+aaaaaaaaaaaa-dirty", true},        // stamped vs unstamped
 		{"v2.1.1", "v2.1.1", true},
-		{"v2.1.1", "v2.1.0", false},                      // real upgrade
-		{"dev+aaaaaaaaaaaa", "v2.1.1", false},            // dev vs release
+		{"v2.1.1", "v2.1.0", false},           // real upgrade
+		{"dev+aaaaaaaaaaaa", "v2.1.1", false}, // dev vs release
 		{"v2.1.1", "dev", false},
 	} {
 		if got := SameBuildClass(tc.a, tc.b); got != tc.want {

--- a/packages/workspace/workspace.go
+++ b/packages/workspace/workspace.go
@@ -157,9 +157,9 @@ func resolveMainGitDir(gitdir string) string {
 	}
 
 	// Fallback: walk up assuming standard .git/worktrees/<name> layout.
-	parent := filepath.Dir(gitdir)           // .git/worktrees
+	parent := filepath.Dir(gitdir) // .git/worktrees
 	if filepath.Base(parent) == "worktrees" {
-		return filepath.Dir(parent)          // .git
+		return filepath.Dir(parent) // .git
 	}
 	return ""
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,23 +1,11 @@
 #!/usr/bin/env bash
 # Build gmuxd and gmux release binaries.
-# Usage: ./scripts/build.sh [--skip-frontend]
+# Usage: ./scripts/build.sh [--skip-frontend] [--print-plan]
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="$ROOT/bin"
 WEB_EMBED="$ROOT/services/gmuxd/cmd/gmuxd/web"
-
-# A toolchain directive is a preferred minimum under GOTOOLCHAIN=auto; a newer
-# ambient Go can still win. Builds must use the repository's exact toolchain.
-GO_TOOLCHAIN="$("$ROOT/scripts/go-toolchain.sh")"
-export GOTOOLCHAIN="$GO_TOOLCHAIN"
-if ! GO_VERSION="$(go version 2>&1)"; then
-  echo "error: required Go toolchain $GO_TOOLCHAIN is unavailable." >&2
-  echo "The go command could not find or download it:" >&2
-  echo "$GO_VERSION" >&2
-  exit 1
-fi
-echo "→ Using $GO_VERSION"
 
 # ── Version stamp ──
 #
@@ -66,24 +54,74 @@ dev_version() {
   echo "dev"
 }
 
+# Mirror of buildversion.IsDev (packages/buildversion): a build "came from a
+# working tree" iff it is "dev" or "dev+<hash>[-dirty]". The Go side is the
+# source of truth — anything that must not be mistaken for a release (the
+# update checker, the daemon replacement policy) asks it — and this shell copy
+# exists only so the build never hands a source binary a release identity.
+is_dev_version() {
+  case "$1" in
+    dev | dev+*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 skip_frontend=false
+print_plan=false
 for arg in "$@"; do
   case "$arg" in
     --skip-frontend) skip_frontend=true ;;
+    # Print the computed stamp and whether the frontend would be rebuilt, then
+    # exit without building anything. The seam scripts/build_test.sh drives.
+    --print-plan) print_plan=true ;;
   esac
 done
 
 # The stamp the currently embedded bundle was built with. A --skip-frontend
-# build must reuse it: the daemon serves that bundle, and version-watch turns
-# any bundle/daemon disagreement into a forced full page load on the next
-# in-app navigation (one lost SPA state per tab, per daemon-only rebuild).
+# build reuses it: the daemon serves that bundle, and version-watch turns any
+# bundle/daemon disagreement into a forced full page load on the next in-app
+# navigation (one lost SPA state per tab, per daemon-only rebuild).
+#
+# The reuse is *guarded*, because the cache is not always adoptable. A single
+# `VERSION=v9.9.9 ./scripts/build.sh` leaves a release string behind, and
+# reusing it would stamp every later daemon-only build v9.9.9: no longer
+# buildversion.IsDev, so the update checker goes online and the daemon/CLI
+# replacement policies treat a source binary as a release. So the stamp is
+# adopted only when it is a dev-class build; and when it disagrees with the
+# version this build stamps anyway, the frontend is rebuilt instead of leaving
+# bundle and daemon at different versions.
 EMBED_STAMP="$BIN/.web-version"
-if [ -z "${VERSION:-}" ] && [ "$skip_frontend" = true ] && [ -s "$EMBED_STAMP" ]; then
-  VERSION="$(cat "$EMBED_STAMP")"
+if [ "$skip_frontend" = true ] && [ -s "$EMBED_STAMP" ]; then
+  embedded_stamp="$(cat "$EMBED_STAMP")"
+  want_version="${VERSION:-$(dev_version)}"
+  if [ -z "${VERSION:-}" ] && is_dev_version "$embedded_stamp"; then
+    VERSION="$embedded_stamp"
+  elif [ "$embedded_stamp" != "$want_version" ]; then
+    echo "→ Embedded bundle is stamped $embedded_stamp, this build stamps $want_version: rebuilding the frontend"
+    skip_frontend=false
+  fi
 fi
 
 VERSION="${VERSION:-$(dev_version)}"
 export VERSION
+
+if [ "$print_plan" = true ]; then
+  echo "version=$VERSION"
+  echo "frontend=$([ "$skip_frontend" = true ] && echo skip || echo build)"
+  exit 0
+fi
+
+# A toolchain directive is a preferred minimum under GOTOOLCHAIN=auto; a newer
+# ambient Go can still win. Builds must use the repository's exact toolchain.
+GO_TOOLCHAIN="$("$ROOT/scripts/go-toolchain.sh")"
+export GOTOOLCHAIN="$GO_TOOLCHAIN"
+if ! GO_VERSION="$(go version 2>&1)"; then
+  echo "error: required Go toolchain $GO_TOOLCHAIN is unavailable." >&2
+  echo "The go command could not find or download it:" >&2
+  echo "$GO_VERSION" >&2
+  exit 1
+fi
+echo "→ Using $GO_VERSION"
 echo "→ Stamping version $VERSION"
 
 mkdir -p "$BIN"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,10 +29,16 @@ dev_version() {
   # The `-e $ROOT/.git` test matters: inside a secondary jj workspace (a grove)
   # there is no .git of its own, and git would happily answer with the *parent*
   # repository's HEAD, which is a different tree.
+  #
+  # --no-optional-locks is what makes "read-only" true rather than nearly true:
+  # `git status` otherwise refreshes the stat cache, which *writes* .git/index
+  # and takes index.lock while doing it. A build must not touch the repository
+  # it is reading, and must not contend with an editor or a jj snapshot for the
+  # index lock.
   if [ -e "$ROOT/.git" ] && command -v git >/dev/null 2>&1 \
-    && hash="$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null)" \
+    && hash="$(git --no-optional-locks -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null)" \
     && [ -n "$hash" ]; then
-    if [ -n "$(git -C "$ROOT" status --porcelain 2>/dev/null)" ]; then
+    if [ -n "$(git --no-optional-locks -C "$ROOT" status --porcelain 2>/dev/null)" ]; then
       echo "dev+$hash-dirty"
     else
       echo "dev+$hash"

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tests for build.sh's version-stamp plan: which version a build stamps, and
+# whether it rebuilds the frontend.
+#
+# Only that decision is tested, via `--print-plan`, which computes the plan and
+# exits before any toolchain or frontend work. The interesting property is not
+# the string but its *class*: a source build must stay buildversion.IsDev, or
+# the update checker goes online and the daemon/CLI replacement policies treat
+# it as a release. The embedded-bundle stamp cache (bin/.web-version) is the
+# one path that can hand a source build a foreign identity, so every case here
+# is about what the cache is allowed to do.
+#
+# Each case runs build.sh from a throwaway ROOT with no VCS of its own, so the
+# computed stamp is the deterministic fallback "dev" and the test never depends
+# on the checkout it runs in.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/build.sh"
+
+SCOREBOARD=$(mktemp)
+WORK=$(mktemp -d)
+trap 'rm -f "$SCOREBOARD"; rm -rf "$WORK"' EXIT
+echo "0 0" > "$SCOREBOARD"
+
+bump_score() {
+  read -r pass fail < "$SCOREBOARD"
+  case "$1" in pass) pass=$((pass + 1)) ;; fail) fail=$((fail + 1)) ;; esac
+  echo "$pass $fail" > "$SCOREBOARD"
+}
+
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then echo "  ✓ $1"; bump_score pass
+  else
+    echo "  ✗ $1"
+    echo "    expected: $(printf %q "$2")"
+    echo "    actual:   $(printf %q "$3")"
+    bump_score fail
+  fi
+}
+
+# plan <embedded stamp or empty> [env assignments...] -- prints "<version> <frontend>"
+plan() {
+  local stamp="$1"; shift
+  local root="$WORK/root"
+  rm -rf "$root"
+  mkdir -p "$root/scripts" "$root/bin"
+  cp "$SCRIPT" "$root/scripts/build.sh"
+  [ -n "$stamp" ] && printf '%s' "$stamp" > "$root/bin/.web-version"
+  local out
+  out="$(env "$@" "$root/scripts/build.sh" --print-plan "${PLAN_ARGS[@]}" 2>&1)" || {
+    echo "build.sh --print-plan failed: $out" >&2
+    return 1
+  }
+  local version frontend
+  version="$(sed -n 's/^version=//p' <<< "$out")"
+  frontend="$(sed -n 's/^frontend=//p' <<< "$out")"
+  echo "$version $frontend"
+}
+
+echo "── full build (no --skip-frontend)"
+PLAN_ARGS=()
+assert_eq "stamps the computed dev version and builds the frontend" \
+  "dev build" "$(plan "" -u VERSION)"
+assert_eq "explicit VERSION wins" \
+  "v1.2.3 build" "$(plan "" VERSION=v1.2.3)"
+assert_eq "a stale release stamp cannot influence a full build" \
+  "dev build" "$(plan "v9.9.9" -u VERSION)"
+
+echo "── --skip-frontend reuses the embedded bundle's stamp"
+PLAN_ARGS=(--skip-frontend)
+assert_eq "adopts a dev-class stamp so bundle and daemon agree" \
+  "dev+1a2b3c4d5e6f~ skip" "$(plan "dev+1a2b3c4d5e6f~" -u VERSION)"
+assert_eq "adopts a dirty dev stamp too" \
+  "dev+1a2b3c4d5e6f-dirty skip" "$(plan "dev+1a2b3c4d5e6f-dirty" -u VERSION)"
+assert_eq "adopts a plain dev stamp" \
+  "dev skip" "$(plan "dev" -u VERSION)"
+assert_eq "no cache: stamps the computed version, nothing to disagree with" \
+  "dev skip" "$(plan "" -u VERSION)"
+
+echo "── --skip-frontend never adopts a non-dev stamp (the footgun)"
+# What `VERSION=v9.9.9 ./scripts/build.sh` leaves behind. Reusing it would make
+# every later daemon-only build claim to be the v9.9.9 release.
+assert_eq "release stamp is refused and the frontend is rebuilt instead" \
+  "dev build" "$(plan "v9.9.9" -u VERSION)"
+assert_eq "a version-shaped-but-not-dev stamp is refused" \
+  "dev build" "$(plan "2.1.2-snapshot-abcdef" -u VERSION)"
+assert_eq "'development' is not dev-class (prefix match must be dev or dev+)" \
+  "dev build" "$(plan "development" -u VERSION)"
+
+echo "── --skip-frontend with an explicit VERSION"
+assert_eq "explicit VERSION matching the bundle keeps the skip" \
+  "v9.9.9 skip" "$(plan "v9.9.9" VERSION=v9.9.9)"
+assert_eq "explicit VERSION disagreeing with the bundle rebuilds the frontend" \
+  "v1.0.0 build" "$(plan "v9.9.9" VERSION=v1.0.0)"
+assert_eq "explicit VERSION is never overridden by a dev-class stamp" \
+  "v1.0.0 build" "$(plan "dev+1a2b3c4d5e6f" VERSION=v1.0.0)"
+
+read -r pass fail < "$SCOREBOARD"
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/gofmt-check.sh
+++ b/scripts/gofmt-check.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Fail if any first-party Go file is not gofmt-clean.
+#
+# `go vet` (the per-module `lint` task) says nothing about formatting, so
+# formatting drift only ever surfaced in review — and did: a deleted function
+# left two stray blank lines in cli/gmux/cmd/gmux/main.go, plus a dozen
+# misaligned comment and struct-tag blocks elsewhere. This costs seconds, so it
+# belongs in the fast `checks` job rather than in a nightly.
+#
+# gofmt's output depends on the toolchain, so use the repository's pinned one
+# (CI's setup-go resolves the same version from go.work).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GO_TOOLCHAIN="$("$ROOT/scripts/go-toolchain.sh")"
+export GOTOOLCHAIN="$GO_TOOLCHAIN"
+
+# `go fmt` shells out to the selected toolchain's gofmt, which is how a pinned
+# toolchain gets honoured: a bare `gofmt` is whatever is on PATH.
+GOFMT="$(go env GOROOT)/bin/gofmt"
+if [ ! -x "$GOFMT" ]; then
+  echo "error: no gofmt in $(go env GOROOT)/bin (toolchain $GO_TOOLCHAIN)" >&2
+  exit 1
+fi
+
+# third_party/ is vendored upstream code and node_modules/ is not ours.
+mapfile -t files < <(cd "$ROOT" && find . -name '*.go' \
+  -not -path './node_modules/*' \
+  -not -path './third_party/*' \
+  -not -path './.git/*' \
+  -not -path './.jj/*' \
+  -not -path './.grove/*' | sort)
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "error: found no Go files under $ROOT" >&2
+  exit 1
+fi
+
+unformatted="$(cd "$ROOT" && "$GOFMT" -l "${files[@]}")"
+if [ -n "$unformatted" ]; then
+  echo "error: these files are not gofmt-clean (run: gofmt -w <file>)" >&2
+  printf '%s\n' "$unformatted" >&2
+  exit 1
+fi
+
+echo "gofmt: ${#files[@]} files clean ($GO_TOOLCHAIN)"

--- a/services/gmuxd/cmd/gmuxd/bootstrap_discovery_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_discovery_test.go
@@ -189,7 +189,7 @@ func newDiscoveryHarness(t *testing.T) *discoveryHarness {
 	}
 	t.Cleanup(func() { store.Close() })
 	h := &discoveryHarness{store: store, errs: &recorder{}, notices: &recorder{}, dir: dir}
-	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1,
 		Store: store, Runners: productionRunnerClient{}, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: productionEndpointSource{},
@@ -508,7 +508,7 @@ func TestScanKeepsProbingUnidentifiableEndpointsButReportsOnce(t *testing.T) {
 	}}
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{ep: meta}, blocked: map[string]bool{}}
 	errs := &recorder{}
-	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1,
 		Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{ep}, nil }),
@@ -548,7 +548,7 @@ func TestScanReportsRepeatedRegistrationFailureOnceOnly(t *testing.T) {
 	const ep = "broken-endpoint" // the fake transport has no meta for it
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{}, blocked: map[string]bool{}}
 	errs := &recorder{}
-	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1,
 		Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{ep}, nil }),

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -437,7 +437,9 @@ func (s *productionRunnerSpawner) resolveCommand(row centralstore.Session) []str
 }
 
 // CanSpawn answers Restart's pre-stop question (sessioncoord.RunnerSpawnChecker)
-// with exactly the predicate Spawn applies, minus any side effect.
+// with exactly the relaunch-command predicate Spawn applies, minus any side
+// effect. Spawn's later steps (directory resolution, socket lease, exec,
+// readiness) are out of scope and still run after the stop.
 func (s *productionRunnerSpawner) CanSpawn(row centralstore.Session) error {
 	if len(s.resolveCommand(row)) == 0 {
 		return relaunchRefusal(row)

--- a/services/gmuxd/cmd/gmuxd/bootstrap_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_test.go
@@ -103,7 +103,7 @@ func TestBootstrapReconstructsActiveSubagentBudgetAfterConvergence(t *testing.T)
 	}
 	meta := sessioncoord.RunnerMeta{Registration: centralstore.RunnerRegistration{ID: child, Adapter: "pi", Alive: true, CreatedAt: 2, ObservedAt: 3, ParentSessionID: &root}, Incarnation: "restart-child"}
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{"child.sock": meta}, blocked: map[string]bool{}}
-	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1,
 		Store: store, Runners: runners, Converter: &wire.Converter{},
 		Endpoints:           EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"child.sock"}, nil }),
 		MaxSubagentsByDepth: []int{1}, SemanticAgent: func(adapter string) bool { return adapter == "pi" },
@@ -142,7 +142,7 @@ func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 	resolver := &bootstrapCountingResolver{}
 	durable := &bootstrapCountingDurable{Durable: store}
 	var reported atomic.Int64
-	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1,
 		Store: store, Durable: durable, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Resolver: resolver, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{endpoint}, nil }),

--- a/services/gmuxd/cmd/gmuxd/central_helpers.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers.go
@@ -64,7 +64,7 @@ type sessionEncodeMemo struct {
 
 	mu           sync.Mutex
 	peerFiltered *wire.SessionsPayload
-	proto2       map[bool][]byte               // peer-filtered? -> marshaled payload
+	proto2       map[bool][]byte                // peer-filtered? -> marshaled payload
 	proto3       map[bool][]sessionstream.Event // peer-filtered? -> transaction events
 }
 
@@ -364,8 +364,8 @@ func centralSessionToLegacy(row centralstore.Session) compatSession {
 		Title:           row.Title,
 		Subtitle:        row.Subtitle,
 		Status:          status,
-		Unread:           row.Unread,
-		UnreadToken: row.UnreadToken,
+		Unread:          row.Unread,
+		UnreadToken:     row.UnreadToken,
 		TerminalCols:    uint16Value(row.TerminalCols),
 		TerminalRows:    uint16Value(row.TerminalRows),
 		Slug:            row.Slug,
@@ -397,8 +397,8 @@ func legacySessionFromWire(s wire.Session) compatSession {
 		Title:           s.Title,
 		Subtitle:        s.Subtitle,
 		Status:          status,
-		Unread:           s.Unread,
-		UnreadToken: s.UnreadToken,
+		Unread:          s.Unread,
+		UnreadToken:     s.UnreadToken,
 		Resumable:       s.Resumable,
 		SocketPath:      s.SocketPath,
 		TerminalCols:    s.TerminalCols,

--- a/services/gmuxd/cmd/gmuxd/reap_route_test.go
+++ b/services/gmuxd/cmd/gmuxd/reap_route_test.go
@@ -193,7 +193,7 @@ func newReapHarness(t *testing.T, session centralstore.SessionID) (*reapHarness,
 
 	installed := startProtocolRunner(t, dir, "1r6zxosb.sock", session, false)
 	h := &reapHarness{dir: dir}
-	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1,
 		Store: store, Runners: productionRunnerClient{}, Control: productionRunnerControl{},
 		Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) {

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1318,8 +1318,8 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			writeError(w, http.StatusInternalServerError, "gmux_not_found", "gmux not found")
 			return
 		}
-		// Refuse before stopping: restart is stop+spawn, so a row the spawner
-		// would refuse must not lose its running process to a failed respawn.
+		// Refuse before stopping: restart is stop+spawn, so a row the relaunch
+		// policy refuses must not lose its running process to a failed respawn.
 		if status, code, msg := relaunchCommandGuard(row); status != 0 {
 			writeError(w, status, code, msg)
 			return

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -1178,6 +1178,7 @@ func recKey(r *placementRec) string {
 	}
 	return "p:" + escape(r.peer) + ":" + escape(r.session)
 }
+
 // placementKeyIndex answers "is recKey k placed in project p" in O(1). Built
 // once per pass so desiredScope stays O(1) per record instead of scanning
 // every placement (O(P²) per rewrite once children exist).

--- a/services/gmuxd/internal/conversations/async_snapshot_test.go
+++ b/services/gmuxd/internal/conversations/async_snapshot_test.go
@@ -30,10 +30,10 @@ type fakeConvAdapter struct {
 	describeGate    chan struct{}
 }
 
-func (f *fakeConvAdapter) Name() string                        { return f.name }
-func (f *fakeConvAdapter) Discover() bool                      { return true }
-func (f *fakeConvAdapter) Match([]string) bool                 { return false }
-func (f *fakeConvAdapter) Env(adapter.EnvContext) []string     { return nil }
+func (f *fakeConvAdapter) Name() string                    { return f.name }
+func (f *fakeConvAdapter) Discover() bool                  { return true }
+func (f *fakeConvAdapter) Match([]string) bool             { return false }
+func (f *fakeConvAdapter) Env(adapter.EnvContext) []string { return nil }
 func (f *fakeConvAdapter) SnapshotConversations(sink adapter.ConversationSink) {
 	if f.inFlight != nil {
 		n := f.inFlight.Add(1)

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -121,11 +121,11 @@ type SpokeDiscovered struct {
 
 // PeerInfo is the public status of a single peer connection.
 type PeerInfo struct {
-	Name            string        `json:"name"`
-	URL             string        `json:"url"`
-	Status          string        `json:"status"`
-	SessionCount    int           `json:"session_count"`
-	LastError       string        `json:"last_error,omitempty"`
+	Name         string `json:"name"`
+	URL          string `json:"url"`
+	Status       string `json:"status"`
+	SessionCount int    `json:"session_count"`
+	LastError    string `json:"last_error,omitempty"`
 	// SessionsOmitted is the number of session rows the peer's last committed
 	// protocol-3 transaction quarantined at the sender (e.g. row_too_large,
 	// transaction_limit). Non-zero means this peer's sessions in the merged
@@ -135,9 +135,9 @@ type PeerInfo struct {
 	// them.
 	SessionsOmitted      int            `json:"sessions_omitted,omitempty"`
 	SessionsOmittedCodes map[string]int `json:"sessions_omitted_codes,omitempty"`
-	Version         string        `json:"version,omitempty"`
-	DefaultLauncher string        `json:"default_launcher,omitempty"`
-	Launchers       []LauncherDef `json:"launchers,omitempty"`
+	Version              string         `json:"version,omitempty"`
+	DefaultLauncher      string         `json:"default_launcher,omitempty"`
+	Launchers            []LauncherDef  `json:"launchers,omitempty"`
 	// Local is true when this peer is conceptually an extension of
 	// the host (a devcontainer discovered by the Docker watcher,
 	// not a network peer). Local peers don't own their own project

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -23,8 +23,8 @@ func (e *ValidationError) Unwrap() error { return e.Err }
 // auto-assignment of sessions to projects. All mutations go through
 // Manager to ensure atomic load+modify+save.
 type Manager struct {
-	mu             sync.Mutex
-	stateDir       string
+	mu       sync.Mutex
+	stateDir string
 
 	// Broadcast is called after every state mutation that should be
 	// synced to connected clients (via SSE). The caller receives the

--- a/services/gmuxd/internal/sessioncoord/lifecycle.go
+++ b/services/gmuxd/internal/sessioncoord/lifecycle.go
@@ -93,10 +93,16 @@ type RunnerSpawner interface {
 }
 
 // RunnerSpawnChecker is an optional extension implemented by spawners that can
-// answer "would you refuse this row?" without launching anything. Restart uses
-// it to refuse *before* stopping: restart is stop+spawn, so a row the spawner
-// would reject must never lose its running process to a doomed respawn.
-// Implementations must be pure and side-effect free.
+// answer "would the relaunch policy refuse this row?" without launching
+// anything. Restart uses it to refuse *before* stopping: restart is stop+spawn,
+// so a row rejected by the relaunch policy must never lose its running process
+// to a doomed respawn.
+//
+// The scope is the command predicate only — whether a command can be resolved
+// for this row — not everything Spawn does. Directory resolution, the socket
+// lease, exec and the readiness timeout still run after the stop and can still
+// fail there; the row then stays relaunchable, so the UI keeps offering
+// recovery. Implementations must be pure and side-effect free.
 type RunnerSpawnChecker interface {
 	CanSpawn(session centralstore.Session) error
 }

--- a/services/gmuxd/internal/update/update.go
+++ b/services/gmuxd/internal/update/update.go
@@ -32,9 +32,16 @@ type Checker struct {
 // If current is a development version the checker does nothing: no goroutine,
 // no network.
 func New(current string) *Checker {
+	return newChecker(current, nil)
+}
+
+// newChecker is New with an injectable transport, so a test can observe
+// whether the checker went to the network at all — the property New's dev-build
+// branch exists for. A nil transport means http.DefaultTransport.
+func newChecker(current string, transport http.RoundTripper) *Checker {
 	c := &Checker{
 		current: current,
-		client:  &http.Client{Timeout: 10 * time.Second},
+		client:  &http.Client{Timeout: 10 * time.Second, Transport: transport},
 	}
 	if buildversion.IsDev(current) {
 		return c

--- a/services/gmuxd/internal/update/update_test.go
+++ b/services/gmuxd/internal/update/update_test.go
@@ -1,6 +1,15 @@
 package update
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
 
 func TestNewer(t *testing.T) {
 	tests := []struct {
@@ -44,15 +53,93 @@ func TestParseSemver(t *testing.T) {
 	}
 }
 
-// The update checker must stay silent — and offline — for every build that
-// came from a working tree, including the stamped "dev+<hash>" a source
-// install produces (scripts/build.sh).
+// recordingTransport answers the releases API and records every request, so a
+// test can assert on "did this checker touch the network at all".
+type recordingTransport struct {
+	tag string
+
+	mu   sync.Mutex
+	urls []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.urls = append(rt.urls, req.URL.String())
+	rt.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"tag_name":%q}`, rt.tag))),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func (rt *recordingTransport) requests() []string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]string(nil), rt.urls...)
+}
+
+// loopGoroutines counts running Checker.loop goroutines. The dev-build
+// contract is "no goroutine", and a lingering loop from an earlier test in
+// this binary makes an absolute count useless, so callers compare a delta.
+func loopGoroutines() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "update.(*Checker).loop(")
+}
+
+// The update checker must stay offline — not merely quiet — for every build
+// that came from a working tree, including the stamped "dev+<hash>" a source
+// install produces (scripts/build.sh). "Quiet" is not the property worth
+// pinning: Available() is "" for any version until a check succeeds, so
+// asserting only that says nothing.
 func TestDevBuildsNeverCheckForUpdates(t *testing.T) {
 	// The predicate itself lives in packages/buildversion (one copy for the
 	// three policies that key off it); pin the behaviour here.
 	for _, v := range []string{"dev", "dev+1a2b3c4d5e6f", "dev+1a2b3c4d5e6f-dirty"} {
-		if c := New(v); c.Available() != "" {
-			t.Errorf("dev build %q reported an available update: %q", v, c.Available())
-		}
+		t.Run(v, func(t *testing.T) {
+			transport := &recordingTransport{tag: "v99.0.0"}
+			before := loopGoroutines()
+			c := newChecker(v, transport)
+
+			// A started loop checks immediately, so a request would already be
+			// recorded; the wait only buys margin on a loaded machine.
+			time.Sleep(200 * time.Millisecond)
+
+			if got := transport.requests(); len(got) != 0 {
+				t.Errorf("dev build %q went to the network: %v", v, got)
+			}
+			if after := loopGoroutines(); after != before {
+				t.Errorf("dev build %q started the checker goroutine (loops %d → %d)", v, before, after)
+			}
+			if c.Available() != "" {
+				t.Errorf("dev build %q reported an available update: %q", v, c.Available())
+			}
+		})
+	}
+}
+
+// The mirror image, so the dev branch cannot pass by never checking at all: a
+// release build does poll, against the releases endpoint, and adopts a newer
+// tag.
+func TestReleaseBuildsCheckForUpdates(t *testing.T) {
+	transport := &recordingTransport{tag: "v9.9.9"}
+	c := newChecker("v2.1.0", transport)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for c.Available() == "" && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := c.Available(); got != "v9.9.9" {
+		t.Fatalf("release build did not pick up the newer release: Available() = %q", got)
+	}
+	requests := transport.requests()
+	if len(requests) == 0 {
+		t.Fatal("release build never contacted the releases API")
+	}
+	if want := "https://api.github.com/repos/" + repo + "/releases/latest"; requests[0] != want {
+		t.Errorf("checked %q, want %q", requests[0], want)
 	}
 }


### PR DESCRIPTION
Eight small residuals from the #526/#527/#528 reviews, one commit each. No behaviour changes beyond the two fixes noted below; the rest is tests, formatting and comments.

### Build

- **`fix(build)`: never let a cached release stamp identify a source build.** `--skip-frontend` reused `bin/.web-version` unconditionally, so a single `VERSION=v9.9.9 ./scripts/build.sh` made every later daemon-only build stamp `v9.9.9` — no longer `buildversion.IsDev`, so the update checker goes online and the daemon/CLI replacement policies treat a source binary as a release. The stamp is now adopted only when it is dev-class, and a cache that disagrees with the version this build stamps triggers a frontend rebuild instead of shipping bundle and daemon at different versions. New `--print-plan` seam + `scripts/build_test.sh` (13 cases, style of the existing release-script tests) wired into the `checks` job; reusing the stamp unconditionally again fails 3 of them.
- **`fix(build)`: keep the version stamp truly read-only.** `git status --porcelain` refreshes the stat cache: it writes `.git/index` and takes `index.lock`. Both git calls now pass `--no-optional-locks`. Verified: `.git/index` byte-identical across stamping runs, a stale `index.lock` changes nothing, dirty detection unchanged (clean → `dev+<hash>`, touch-only → no marker, real edit → `-dirty`).

### Formatting gate

- **`style(go)`: gofmt the tree and gate formatting in CI.** Removing `isDevVersion` left two stray blank lines in `cli/gmux/cmd/gmux/main.go`; twelve other files had misaligned comments/struct tags. `go vet` says nothing about formatting, so nothing caught it. `scripts/gofmt-check.sh` (pinned toolchain via `go-toolchain.sh`, 421 files in 0.3s) runs in `checks`.

### Tests that were not pinning their property

- **`test(update)`: dev builds stay offline, releases don't.** `TestDevBuildsNeverCheckForUpdates` asserted `New(v).Available() == ""`, true for any input. Now, with an injectable transport: each dev-class stamp records zero requests and adds no `Checker.loop` goroutine, and a release build does hit `repos/<repo>/releases/latest` and adopts the newer tag. Mutants killed: `IsDev` narrowed to `== "dev"`, guard neutered, `go c.loop()` dropped.
- **`test(e2e)`: pin the pill tap's never-commit-a-refusal guard.** `fitAndResize` (the reclaim pill's tap handler) survived reverting in the whole suite. Reviewer's shape: second WS client sizes the PTY to 40×10, collapse the shell below one cell, dispatch `el.click()` on the pill (a `locator.click()` on a 0-height overlay is not actionable). Reverting to commit-then-check fails it.
- **`test(web)`: `delete process.env.TZ`** instead of assigning back an undefined `savedTZ`, which stores the literal `"undefined"` → Node resolves it to UTC and vitest reuses workers across files.

### Web fix

- **`fix(web)`: tell the user when a restart was relocated too.** `restartSession` posted without `onData`, dropping the same `original_cwd`/`fallback_cwd` payload `resumeSession` toasts — a restart whose recorded directory is gone reruns the recorded command elsewhere, silently. Pinned at the store seam (both cases) plus the pure function; removing the `onData` block fails the store test.

### Comment

- **`docs(sessioncoord)`:** `RunnerSpawnChecker` covers the relaunch *command* predicate only — directory resolution, socket lease, exec and readiness still run after the stop. Reworded at the interface, at `CanSpawn`, and at the restart route's call site.

### Verification

`gofmt-check` + `go vet` (both modules) clean; `go test -race` on `internal/update`, `internal/sessioncoord`, `cmd/gmuxd`, `internal/{peering,projects,centralstore,conversations}`, `cli/gmux/cmd/gmux`, `packages/{buildversion,workspace}`; `tsc --noEmit`; `pnpm lint`; `pnpm build`; vitest (46 files); `./scripts/build.sh`, the `--skip-frontend` sequence and the poisoned-cache case end-to-end; Playwright `terminal-resize` 7/7 and `relaunch-affordance` + `terminal-claim-retry` + `no-external-network` 8/8.

Known pre-existing flake (not from this PR): `store-projections.test.ts` "randomized world seed=1/2" hits vitest's 5 s per-test timeout when the whole suite runs in parallel on a loaded machine — reproduced identically on base `main` (55b8660) here, and the file passes 12/12 standalone even under 8 busy-loops.